### PR TITLE
Harden e2e tests per UI test guidance

### DIFF
--- a/src/components/AudioErrorGuard.vue
+++ b/src/components/AudioErrorGuard.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="hasError" class="audio-error-guard">
+  <div v-if="hasError" class="audio-error-guard" data-testid="audioErrorGuard">
     <div class="error-content">
       <h1>{{ t('errors.audioUnavailable.title') }}</h1>
-      <p>{{ t('errors.audioUnavailable.message') }}</p>
+      <p data-testid="audioErrorGuardMessage">{{ t('errors.audioUnavailable.message') }}</p>
     </div>
   </div>
   <slot v-else />

--- a/tests/e2e/components/AudioErrorGuard.ts
+++ b/tests/e2e/components/AudioErrorGuard.ts
@@ -12,9 +12,9 @@ export class AudioErrorGuard {
 
   constructor(page: Page) {
     this.page = page
-    this.container = page.locator('.audio-error-guard')
+    this.container = page.getByTestId('audioErrorGuard')
     this.title = this.container.getByRole('heading', { level: 1 })
-    this.message = this.container.locator('p')
+    this.message = this.container.getByTestId('audioErrorGuardMessage')
   }
 
   async boundingBox() {

--- a/tests/e2e/components/TestField.ts
+++ b/tests/e2e/components/TestField.ts
@@ -26,20 +26,18 @@ export class TestField {
     // Wait for the answer to be populated (it's set onMounted)
     await expect(this.answerKey).not.toHaveValue('', { timeout: 10000 })
 
-    // Wait for the answer to stabilize (Vue may regenerate it)
-    let answer = ''
-    let stableCount = 0
-    while (stableCount < 3) {
-      const currentAnswer = await this.answerKey.inputValue()
-      if (currentAnswer === answer) {
-        stableCount++
-      } else {
-        answer = currentAnswer
-        stableCount = 0
-      }
-      // Small polling interval for stability check
-      await this.page.waitForTimeout(100)
-    }
+    // Wait for the answer to stabilize (Vue may regenerate it). expect.poll
+    // auto-waits between attempts, so the value must read the same across
+    // consecutive polls before we proceed.
+    let previousAnswer = ''
+    let answer = await this.answerKey.inputValue()
+    await expect
+      .poll(async () => {
+        previousAnswer = answer
+        answer = await this.answerKey.inputValue()
+        return answer === previousAnswer
+      })
+      .toBe(true)
 
     const textToType = answerFunction(answer)
 

--- a/tests/e2e/flows/startSeededLesson.ts
+++ b/tests/e2e/flows/startSeededLesson.ts
@@ -1,0 +1,42 @@
+import { type Page } from '@playwright/test'
+import { ResumePage } from '../pages/ResumePage'
+import { LessonPage } from '../pages/LessonPage'
+
+/**
+ * Handles returned by {@link startSeededLesson} so callers can compose the
+ * next step of a flow or make feature assertions.
+ */
+export interface SeededLesson {
+  /** The page seeded with progress and resumed into the lesson. */
+  page: Page
+  /** The resume screen the user passed through. */
+  resumePage: ResumePage
+  /** The lesson the user resumed into. */
+  lessonPage: LessonPage
+}
+
+/**
+ * Seeds a returning user's progress, then resumes into their lesson.
+ *
+ * Composes the {@link ResumePage} and {@link LessonPage} construction that is
+ * otherwise duplicated across the lesson specs: it seeds localStorage via the
+ * `createPageWithStorage` fixture factory and clicks through the resume screen.
+ * Only synchronizes; feature assertions belong in the spec.
+ *
+ * @param createPageWithStorage The fixture factory that opens a page with
+ *   seeded localStorage.
+ * @param storage The localStorage entries to seed (e.g. `lastAchievedLesson`).
+ * @returns The page plus the resume and lesson handles the next step needs.
+ */
+export async function startSeededLesson(
+  createPageWithStorage: (storage: Record<string, string>) => Promise<Page>,
+  storage: Record<string, string>,
+): Promise<SeededLesson> {
+  const page = await createPageWithStorage(storage)
+  const resumePage = new ResumePage(page)
+  const lessonPage = new LessonPage(page)
+
+  await resumePage.clickLetsDoIt()
+
+  return { page, resumePage, lessonPage }
+}

--- a/tests/e2e/lesson.spec.ts
+++ b/tests/e2e/lesson.spec.ts
@@ -4,6 +4,7 @@ import { LessonPage } from './pages/LessonPage'
 import { ResumePage } from './pages/ResumePage'
 import { StartPage } from './pages/StartPage'
 import { CompletedPage } from './pages/CompletedPage'
+import { startSeededLesson } from './flows/startSeededLesson'
 
 test.describe('Lesson', () => {
   test.describe('Testing to completion', () => {
@@ -40,11 +41,9 @@ test.describe('Lesson', () => {
     })
 
     test('gets extra credit', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '0' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const { lessonPage } = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '0',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('r')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -62,11 +61,9 @@ test.describe('Lesson', () => {
     })
 
     test('gets a perfect score', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '1' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const { lessonPage } = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '1',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('s')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -83,14 +80,10 @@ test.describe('Lesson', () => {
 
   test.describe('Other testing', () => {
     test('recovers from an abandoned test via retry', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({
+      const { lessonPage } = await startSeededLesson(createPageWithStorage, {
         lastAchievedLesson: '2',
         e2eShortAbandon: 'true',
       })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
 
       await expect(lessonPage.symbolGuide.symbolKey('u')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -117,11 +110,9 @@ test.describe('Lesson', () => {
     })
 
     test('moves between lessons with the arrow key', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '2' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const { lessonPage } = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '2',
+      })
 
       await lessonPage.pressArrowLeft()
       await expect(lessonPage.symbolGuide.symbolKey('s')).toHaveClass(/hover/)
@@ -138,11 +129,9 @@ test.describe('Lesson', () => {
 
   test.describe('Completion', () => {
     test('completes the whole course', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '48' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const { lessonPage } = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '48',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('@')).toHaveClass(/hover/, {
         timeout: 10000,


### PR DESCRIPTION
## Summary

Addresses three findings from the e2e test audit, aligning the Playwright suite with the UI test guidance (resilient locators, web-first assertions, layered flow helpers).

## Findings addressed

- **Finding 1 — locator resilience (`tests/e2e/components/AudioErrorGuard.ts`).** Replaced the brittle `.audio-error-guard` CSS-class and bare `p` locators with testids. Added `data-testid="audioErrorGuard"` (container) and `data-testid="audioErrorGuardMessage"` (message) to the real Vue source (`src/components/AudioErrorGuard.vue`) and switched the component object to `getByTestId`. The heading still uses `getByRole('heading', { level: 1 })`.
- **Finding 2 — web-first assertion (`tests/e2e/components/TestField.ts`).** `typeAnswer` no longer polls `inputValue()` in a loop with `waitForTimeout(100)`. It now uses an auto-waiting `expect.poll` that waits for the answer value to read the same across consecutive attempts before proceeding — no fixed sleep.
- **Finding 3 — flow helper (`tests/e2e/lesson.spec.ts`).** Extracted the duplicated seed-and-resume construction into a composed flow helper `startSeededLesson()` under `tests/e2e/flows/`, used across the affected specs. The helper only synchronizes (seeds storage via the fixture factory, clicks through resume) and returns the `{ page, resumePage, lessonPage }` handles; feature assertions stay in the specs.

### Intentional deferral

- The `returns to a lesson` spec keeps its inline `ResumePage`/`LessonPage` construction because its purpose is to assert the resume screen heading is visible **before** resuming. That assert-then-resume sequence is a distinct flow from the helper's seed-and-resume, so folding it in would either drop the feature assertion or branch the helper.

## Verification

- `pnpm type-check` (vue-tsc): pass, no errors
- `pnpm lint` (eslint, stylelint, oxlint, knip): pass, clean
- `pnpm test:unit` (vitest): 36 passed
- `npx playwright test --list`: all 13 specs compile
- Full Playwright run (chromium): 13/13 passed against a stable preview server (11 lesson + 2 audio-error). The new testids render and are located; `expect.poll` stabilization and the `startSeededLesson` flow work across all refactored specs. Note: running Playwright's auto-`build && vite preview` webServer under parallel load was flaky in this sandbox (the preview process got torn down mid-run, causing `ERR_CONNECTION_REFUSED` in the fixture's `page.goto`); running serially against a pre-started preview server passed everything. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)