### PR TITLE
test(e2e): apply resilient-locator and web-first test guidance

### DIFF
--- a/src/components/AudioErrorGuard.vue
+++ b/src/components/AudioErrorGuard.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="hasError" class="audio-error-guard">
+  <div v-if="hasError" class="audio-error-guard" data-testid="audioErrorGuard">
     <div class="error-content">
       <h1>{{ t('errors.audioUnavailable.title') }}</h1>
-      <p>{{ t('errors.audioUnavailable.message') }}</p>
+      <p data-testid="audioErrorGuardMessage">{{ t('errors.audioUnavailable.message') }}</p>
     </div>
   </div>
   <slot v-else />

--- a/tests/e2e/components/AudioErrorGuard.ts
+++ b/tests/e2e/components/AudioErrorGuard.ts
@@ -12,9 +12,9 @@ export class AudioErrorGuard {
 
   constructor(page: Page) {
     this.page = page
-    this.container = page.locator('.audio-error-guard')
+    this.container = page.getByTestId('audioErrorGuard')
     this.title = this.container.getByRole('heading', { level: 1 })
-    this.message = this.container.locator('p')
+    this.message = this.container.getByTestId('audioErrorGuardMessage')
   }
 
   async boundingBox() {

--- a/tests/e2e/components/TestField.ts
+++ b/tests/e2e/components/TestField.ts
@@ -26,21 +26,27 @@ export class TestField {
     // Wait for the answer to be populated (it's set onMounted)
     await expect(this.answerKey).not.toHaveValue('', { timeout: 10000 })
 
-    // Wait for the answer to stabilize (Vue may regenerate it)
-    let answer = ''
+    // Wait for the answer to stabilize (Vue may regenerate it): the value must
+    // stay non-empty and unchanged across consecutive auto-retried polls.
+    let previousAnswer = ''
     let stableCount = 0
-    while (stableCount < 3) {
-      const currentAnswer = await this.answerKey.inputValue()
-      if (currentAnswer === answer) {
-        stableCount++
-      } else {
-        answer = currentAnswer
-        stableCount = 0
-      }
-      // Small polling interval for stability check
-      await this.page.waitForTimeout(100)
-    }
+    await expect
+      .poll(
+        async () => {
+          const currentAnswer = await this.answerKey.inputValue()
+          if (currentAnswer !== '' && currentAnswer === previousAnswer) {
+            stableCount++
+          } else {
+            stableCount = 0
+          }
+          previousAnswer = currentAnswer
+          return stableCount
+        },
+        { timeout: 10000 },
+      )
+      .toBeGreaterThanOrEqual(3)
 
+    const answer = previousAnswer
     const textToType = answerFunction(answer)
 
     // Focus the textbox first to ensure it's ready for input

--- a/tests/e2e/flows/startSeededLesson.ts
+++ b/tests/e2e/flows/startSeededLesson.ts
@@ -1,0 +1,44 @@
+import { expect, type Page } from '@playwright/test'
+import { LessonPage } from '../pages/LessonPage'
+import { ResumePage } from '../pages/ResumePage'
+
+type StartSeededLessonOptions = {
+  /** The lesson index to seed into `lastAchievedLesson` localStorage. */
+  lastAchievedLesson: string
+  /** Additional localStorage entries to seed before the app loads. */
+  storage?: Record<string, string>
+  /**
+   * Whether to assert the resume page heading is visible before resuming.
+   * Defaults to `false`.
+   */
+  expectResumeHeading?: boolean
+}
+
+/**
+ * Seeds progress into a fresh page, then resumes into the lesson view.
+ *
+ * Composes {@link ResumePage} and {@link LessonPage} so specs don't repeat the
+ * seed-then-resume construction. The only assertions performed here are
+ * synchronization (resuming waits for the lesson view); feature assertions stay
+ * in the spec.
+ *
+ * @param createPageWithStorage The fixture factory that seeds localStorage.
+ * @param options The lesson seed and optional extra storage.
+ * @returns The {@link LessonPage} for the resumed lesson.
+ */
+export async function startSeededLesson(
+  createPageWithStorage: (storage: Record<string, string>) => Promise<Page>,
+  { lastAchievedLesson, storage = {}, expectResumeHeading = false }: StartSeededLessonOptions,
+): Promise<LessonPage> {
+  const page = await createPageWithStorage({ lastAchievedLesson, ...storage })
+  const resumePage = new ResumePage(page)
+  const lessonPage = new LessonPage(page)
+
+  if (expectResumeHeading) {
+    await expect(resumePage.heading).toBeVisible()
+  }
+
+  await resumePage.clickLetsDoIt()
+
+  return lessonPage
+}

--- a/tests/e2e/lesson.spec.ts
+++ b/tests/e2e/lesson.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from './fixtures/fixtures'
 import { repeat } from 'lodash-es'
 import { LessonPage } from './pages/LessonPage'
-import { ResumePage } from './pages/ResumePage'
 import { StartPage } from './pages/StartPage'
 import { CompletedPage } from './pages/CompletedPage'
+import { startSeededLesson } from './flows/startSeededLesson'
 
 test.describe('Lesson', () => {
   test.describe('Testing to completion', () => {
@@ -40,11 +40,9 @@ test.describe('Lesson', () => {
     })
 
     test('gets extra credit', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '0' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '0',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('r')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -62,11 +60,9 @@ test.describe('Lesson', () => {
     })
 
     test('gets a perfect score', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '1' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '1',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('s')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -83,14 +79,10 @@ test.describe('Lesson', () => {
 
   test.describe('Other testing', () => {
     test('recovers from an abandoned test via retry', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
         lastAchievedLesson: '2',
-        e2eShortAbandon: 'true',
+        storage: { e2eShortAbandon: 'true' },
       })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
 
       await expect(lessonPage.symbolGuide.symbolKey('u')).toHaveClass(/hover/, {
         timeout: 10000,
@@ -106,22 +98,18 @@ test.describe('Lesson', () => {
     })
 
     test('returns to a lesson', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '2' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await expect(resumePage.heading).toBeVisible()
-      await resumePage.clickLetsDoIt()
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '2',
+        expectResumeHeading: true,
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('u')).toHaveClass(/hover/)
     })
 
     test('moves between lessons with the arrow key', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '2' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '2',
+      })
 
       await lessonPage.pressArrowLeft()
       await expect(lessonPage.symbolGuide.symbolKey('s')).toHaveClass(/hover/)
@@ -138,11 +126,9 @@ test.describe('Lesson', () => {
 
   test.describe('Completion', () => {
     test('completes the whole course', async ({ createPageWithStorage }) => {
-      const page = await createPageWithStorage({ lastAchievedLesson: '48' })
-      const resumePage = new ResumePage(page)
-      const lessonPage = new LessonPage(page)
-
-      await resumePage.clickLetsDoIt()
+      const lessonPage = await startSeededLesson(createPageWithStorage, {
+        lastAchievedLesson: '48',
+      })
 
       await expect(lessonPage.symbolGuide.symbolKey('@')).toHaveClass(/hover/, {
         timeout: 10000,


### PR DESCRIPTION
## Summary

Applies three audited Playwright e2e findings toward the resilient-locator / web-first test guidance. The diff is scoped to the tests (plus two `data-testid` attributes on the component under test); no production behavior changes.

### Findings addressed

- **Finding 1 — locator resilience (`tests/e2e/components/AudioErrorGuard.ts`).** The component object selected `.audio-error-guard` and a bare `p`. Added `data-testid="audioErrorGuard"` (container) and `data-testid="audioErrorGuardMessage"` (message) to the real Vue source (`src/components/AudioErrorGuard.vue`) and switched the object to `getByTestId`. The heading still uses `getByRole('heading', { level: 1 })`.
- **Finding 2 — web-first assertion (`tests/e2e/components/TestField.ts`).** `typeAnswer` polled `inputValue()` in a loop with a fixed `waitForTimeout(100)`. Replaced the fixed-delay polling with an auto-waiting `expect.poll` that synchronizes on the answer value going non-empty and staying stable across consecutive retries — no fixed sleep.
- **Finding 3 — flow helper (`tests/e2e/lesson.spec.ts`).** The seed-then-resume construction (`createPageWithStorage` -> `new ResumePage` -> `new LessonPage` -> `clickLetsDoIt`) was duplicated across six specs. Extracted `startSeededLesson(...)` under `tests/e2e/flows/`; it performs the seed + resume action and returns the `LessonPage` the spec needs. Feature assertions stay in the specs (the one spec that asserts the resume heading before resuming passes `expectResumeHeading: true`).

### Deferred

None. The three Completion-block specs (`practices and fails/succeeds`, `restarts progress`) use the `CompletedPage` flow rather than the resume flow, so they are intentionally left unchanged — they were not part of the duplicated resume construction.

## Verification

All run on Node 26.3.0 / pnpm 11.5.1:

- `pnpm type-check` (vue-tsc): pass
- `pnpm lint` (eslint, stylelint, oxlint, knip): pass
- `CI=true pnpm test:unit` (vitest): 36 passed
- `npx playwright test --list`: 13 tests compile
- `npx playwright test` (full suite, webServer auto-built): **13 passed** — including both audio-error specs (confirming the new test ids render) and all six specs now using `startSeededLesson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)